### PR TITLE
http: req end after close

### DIFF
--- a/test/parallel/test-http-server-keepalive-end.js
+++ b/test/parallel/test-http-server-keepalive-end.js
@@ -3,9 +3,16 @@
 const common = require('../common');
 const { createServer } = require('http');
 const { connect } = require('net');
+const assert = require('assert');
 
 const server = createServer(common.mustCall((req, res) => {
-  req.on('end', common.mustCall());
+  let closeEmitted = false;
+  req.on('close', () => {
+    closeEmitted = true;
+  })
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(closeEmitted, false);
+  }));
   res.end('hello world');
 }));
 


### PR DESCRIPTION
`'end'` can be emitted after `'close'`. This can cause e.g. `pipeline` to error with a `ERR_STREAM_PREMATURE_CLOSE`.

Fix missing.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
