### PR TITLE
stream: compact readable small element buffering

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -320,6 +320,15 @@ function addChunk(stream, state, chunk, addToFront) {
     else
       state.buffer.push(chunk);
 
+    if (!state.objectMode && state.length < state.highWaterMark) {
+      // Compact buffer if it contains lots of small elements.
+      // We estimate that each buffer element is 16 bytes
+      // (i.e. 2 properties * 8 bytes each).
+      const bufferOverhead = state.buffer.length * 16;
+      if (state.length + bufferOverhead > state.highWaterMark)
+        compact(state);
+    }
+
     if (state.needReadable)
       emitReadable(stream);
   }
@@ -1129,6 +1138,14 @@ function fromList(n, state) {
   }
 
   return ret;
+}
+
+function compact({ buffer, decoder, objectMode, length }) {
+  if (!objectMode && buffer.length > 1) {
+    const v = decoder ? buffer.join('') : buffer.concat(length);
+    buffer.clear();
+    buffer.push(v);
+  }
 }
 
 function endReadable(stream) {

--- a/test/parallel/test-stream-readable-hwm-0-small.js
+++ b/test/parallel/test-stream-readable-hwm-0-small.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const assert = require('assert');
+const { Readable } = require('stream');
+
+{
+  const r = new Readable({
+    read: ()=> {},
+    highWaterMark: 32,
+  });
+
+  r.push('a');
+  r.push('b');
+  r.push('c');
+
+  // buffer should be compacted.
+  assert.strictEqual(r._readableState.buffer.length, 1);
+}
+
+{
+  const r = new Readable({
+    read: ()=> {},
+    highWaterMark: 50,
+  });
+
+  r.push('a');
+  r.push('b');
+
+  // buffer should not compacted.
+  assert.strictEqual(r._readableState.buffer.length, 2);
+}


### PR DESCRIPTION
When buffering lots of small elements the actual memory usage
can unexpectedly and significantly exceed the configured
highWaterMark. Try to compact the buffer when we estimate this
is about to happen.

Refs: #29310

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
