### PR TITLE
http: IncomingMessage destroyed state

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -318,7 +318,9 @@ ClientRequest.prototype.abort = function abort() {
 
   // If we're aborting, we don't care about any more response data.
   if (this.res) {
-    this.res._dump();
+    // TODO(ronag): No more data events should occur after destroy.
+    this.res.removeAllListeners('data');
+    this.res.destroy();
   }
 
   // In the event that we don't have a socket, we will pop out of
@@ -365,11 +367,11 @@ function socketCloseListener() {
     req.emit('close');
     if (res.readable) {
       res.on('end', function() {
-        this.emit('close');
+        res.destroy();
       });
       res.push(null);
     } else {
-      res.emit('close');
+      res.destroy();
     }
   } else {
     if (!req.socket._hadError) {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -109,9 +109,11 @@ IncomingMessage.prototype._read = function _read(n) {
 // It's possible that the socket will be destroyed, and removed from
 // any messages, before ever calling this.  In that case, just skip
 // it, since something else is destroying this connection anyway.
-IncomingMessage.prototype.destroy = function destroy(error) {
+IncomingMessage.prototype._destroy = function destroy(err, cb) {
   if (this.socket)
-    this.socket.destroy(error);
+    this.socket.destroy(err, cb);
+  else
+    cb(err);
 };
 
 

--- a/test/parallel/test-http-request-destroy.js
+++ b/test/parallel/test-http-request-destroy.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+{
+  const server = http.Server(function(req, res) {
+    req.destroy();
+    assert.strictEqual(req.destroyed, true);
+  });
+
+  server.listen(0, function() {
+    http.get({
+      port: this.address().port,
+    }).on('error', common.mustCall(() => {
+      server.close();
+    }));
+  });
+}
+
+{
+  const server = http.Server(function(req, res) {
+    req.destroy(new Error('kaboom'));
+    req.destroy(new Error('kaboom2'));
+    assert.strictEqual(req.destroyed, true);
+    req.on('error', common.mustCall((err) => {
+      assert.strictEqual(err.message, 'kaboom');
+    }));
+  });
+
+  server.listen(0, function() {
+    http.get({
+      port: this.address().port,
+    }).on('error', common.mustCall(() => {
+      server.close();
+    }));
+  });
+}


### PR DESCRIPTION
IncomingMessage should implement _destroy() instead of overriding
destroy() in order to behave properly like a stream.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
